### PR TITLE
Fix production build (closes #4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ build:
 	- rm -r dist/
 	mkdir -p dist/jspm_packages
 	mkdir -p dist/app/vendor
-	./node_modules/.bin/jspm bundle app/main dist/app.min.js --minify --log err
+	./node_modules/.bin/jspm bundle app/main dist/app.min.js --minify --log err --source-map-contents
 	cp app/vendor/*.js dist/app/vendor
 	cp jspm_packages/system.js dist/jspm_packages
 	cp config.js dist

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dependencies": {
       "capaj/jspm-hot-reloader": "github:capaj/jspm-hot-reloader@^0.4.2",
       "css": "github:systemjs/plugin-css@^0.1.19",
-      "ecmascript-evaluator": "npm:ecmascript-evaluator@^0.0.3",
+      "ecmascript-evaluator": "npm:ecmascript-evaluator@^0.0.6",
       "fetch": "npm:whatwg-fetch@^0.10.1",
       "react": "npm:react@^0.14.2",
       "react-codemirror": "npm:react-codemirror@^0.2.0",


### PR DESCRIPTION
Hey!

As discussed in #4 production build is broken because JSPM deps are locked on ecmascript-evaluator 0.0.3 (caret deps are as good as exact deps for 0.0.x versions). So it doesn't benefit from minification fixes in 0.0.6.

This fixes this by altering the dep declaration. And I thought having usable source maps in production would be nice, too, as the existing bundle call in `Makefile` only listed filenames, without embedding file contents, making it difficult to debug in a production context (as I had to do), so I fixed the bundle call for this.
