### PR TITLE
Handle evaluation errors in transpiled ES6 code

### DIFF
--- a/app/components/challenge.js
+++ b/app/components/challenge.js
@@ -70,9 +70,9 @@ export default class Challenge extends React.Component {
 
   evaluateCode(e) {
     e.preventDefault();
-    Evaluator.run(this.state.src).then((results) => {
-      // TODO: Evaluato 0.0.6 returns a promise so we should use that
-      // and then we can catch the error
+    const handleResults = (results) => {
+      // The evaluator returns either a fulfilled or rejected promise, but
+      // always with the same result/error object, so we handle both here
       if (results[0].error) {
         const { errorType, message } = results[0];
         this.setState({
@@ -87,7 +87,9 @@ export default class Challenge extends React.Component {
       }
 
       this.logActivity(results);
-    });
+    }
+    
+    Evaluator.run(this.state.src).then(handleResults, handleResults);
   }
 
   logActivity(res) {

--- a/app/components/challenge.js
+++ b/app/components/challenge.js
@@ -70,9 +70,9 @@ export default class Challenge extends React.Component {
 
   evaluateCode(e) {
     e.preventDefault();
+    // The evaluator returns either a fulfilled or rejected promise, but
+    // always with the same result/error object, so we handle both here
     const handleResults = (results) => {
-      // The evaluator returns either a fulfilled or rejected promise, but
-      // always with the same result/error object, so we handle both here
       if (results[0].error) {
         const { errorType, message } = results[0];
         this.setState({
@@ -89,7 +89,7 @@ export default class Challenge extends React.Component {
       this.logActivity(results);
     }
     
-    Evaluator.run(this.state.src).then(handleResults, handleResults);
+    Evaluator.run(this.state.src).then(handleResults).catch(handleResults);
   }
 
   logActivity(res) {


### PR DESCRIPTION
Rejected promises due to evaluation errors (e.g. `ReferenceError`, `SyntaxError`) would get ignored (causing a page-wide uncaught-exception notification in recent Chromes, for instance), which looks like non-functioning eval from a UX standpoint.

This fix turns such errors into regular error reporting, so it shows up in the eval parts.
